### PR TITLE
Cleanup of TranslationUnit and CodeCompleteResults.

### DIFF
--- a/src/CodeCompleteResults.cc
+++ b/src/CodeCompleteResults.cc
@@ -23,29 +23,6 @@ clang::CodeCompleteResults::CodeCompleteResults(CXTranslationUnit &cx_tu,
     clang_sortCodeCompletionResults(cx_results->Results, cx_results->NumResults);
 }
 
-clang::CodeCompleteResults::CodeCompleteResults(CXTranslationUnit &cx_tu,
-                                                const std::string &file_name,
-                                                const std::map<std::string, std::string> &buffers,
-                                                unsigned line_num, unsigned column) {
-  std::vector<CXUnsavedFile> files;
-  for (auto &buffer : buffers) {
-    CXUnsavedFile file;
-    file.Filename = buffer.first.c_str();
-    file.Contents = buffer.second.c_str();
-    file.Length = buffer.second.size();
-    files.push_back(file);
-  }
-  cx_results = clang_codeCompleteAt(cx_tu,
-                                  file_name.c_str(),
-                                  line_num,
-                                  column,
-                                  files.data(),
-                                  files.size(),
-                                  clang_defaultCodeCompleteOptions()|CXCodeComplete_IncludeBriefComments);
-  if(cx_results!=NULL)
-    clang_sortCodeCompletionResults(cx_results->Results, cx_results->NumResults);
-}
-
 clang::CodeCompleteResults::~CodeCompleteResults() {
   clang_disposeCodeCompleteResults(cx_results);
 }

--- a/src/CodeCompleteResults.h
+++ b/src/CodeCompleteResults.h
@@ -11,10 +11,6 @@ namespace clang {
     
     CodeCompleteResults(CXTranslationUnit &cx_tu, const std::string &buffer,
                         unsigned line_num, unsigned column);
-    //TODO: remove
-    CodeCompleteResults(CXTranslationUnit &cx_tu, const std::string &file_path,
-                        const std::map<std::string, std::string>  &buffers,
-                        unsigned line_num, unsigned column);
   public:
     ~CodeCompleteResults();
     CompletionString get(unsigned index) const;

--- a/src/TranslationUnit.h
+++ b/src/TranslationUnit.h
@@ -14,28 +14,18 @@
 namespace clang {
   class TranslationUnit {
   public:
-    //TODO: remove
-    TranslationUnit(Index &index,
-                    const std::string &file_path,
-                    const std::vector<std::string> &command_line_args);
     TranslationUnit(Index &index,
                     const std::string &file_path,
                     const std::vector<std::string> &command_line_args,
                     const std::string &buffer,
                     unsigned flags=DefaultFlags());
-    //TODO: remove
     TranslationUnit(Index &index,
                     const std::string &file_path,
                     const std::vector<std::string> &command_line_args,
-                    const std::map<std::string, std::string> &buffers,
                     unsigned flags=DefaultFlags());
-    TranslationUnit(Index &index, const std::string &file_path);
     ~TranslationUnit();
     
     int ReparseTranslationUnit(const std::string &buffer, unsigned flags=DefaultFlags());
-    //TODO: remove
-    int ReparseTranslationUnit(const std::map<std::string, std::string> &buffers,
-                               unsigned flags=DefaultFlags());
     
     static unsigned DefaultFlags();
     
@@ -46,9 +36,6 @@ namespace clang {
                unsigned flags=DefaultFlags());
 
     clang::CodeCompleteResults get_code_completions(const std::string &buffer,
-                                                    unsigned line_number, unsigned column);
-    //TODO: remove
-    clang::CodeCompleteResults get_code_completions(const std::map<std::string, std::string> &buffers,
                                                     unsigned line_number, unsigned column);
 
     std::vector<clang::Diagnostic> get_diagnostics();

--- a/tests/CodeCompleteResults_H_Test.cc
+++ b/tests/CodeCompleteResults_H_Test.cc
@@ -9,26 +9,18 @@ BOOST_AUTO_TEST_CASE(code_complete_results) {
   std::string path("./case/main.cpp");
 
   clang::Index index(0, 0);
-  clang::TranslationUnit tu(index, path);
+  clang::TranslationUnit tu(index, path, {});
 
-  // ReparseTranslationUnit takes a map with filepath as key
-  // and buffer as value
-  std::map<std::string, std::string> buffers;
-
-  // create buffer
-  std::string file;
-  file.append("#include <string>\n");
-  file.append("int main(int argc, char *argv[]) {\n");
-  file.append("std::string str;\n");
-  file.append("str.\n");
-  file.append("return 0\n");
-  file.append("}");
-
-  buffers[path] = file;
+  std::string buffer="#include <string>\n"
+                     "int main(int argc, char *argv[]) {\n"
+                     "std::string str;\n"
+                     "str.\n"
+                     "return 0\n"
+                     "}";
 
   // ]
 
-  auto results=tu.get_code_completions(buffers, 4, 5);
+  auto results=tu.get_code_completions(buffer, 4, 5);
 
   bool substr_found=false;
   for(unsigned c=0;c<results.size();c++) {

--- a/tests/CompletionString_H_Test.cc
+++ b/tests/CompletionString_H_Test.cc
@@ -16,24 +16,16 @@ BOOST_AUTO_TEST_CASE(completion_string) {
   std::string path("./case/main.cpp");
 
   clang::Index index(0, 0);
-  clang::TranslationUnit tu(index, path);
+  clang::TranslationUnit tu(index, path, {});
 
-  // ReparseTranslationUnit takes a map with filepath as key
-  // and buffer as value
-  std::map<std::string, std::string> buffers;
+  std::string buffer="#include <string>\n"
+                     "int main(int argc, char *argv[]) {\n"
+                     "std::string str;\n"
+                     "str.\n"
+                     "return 0\n"
+                     "}";
 
-  // create buffer
-  std::string file;
-  file.append("#include <string>\n");
-  file.append("int main(int argc, char *argv[]) {\n");
-  file.append("std::string str;\n");
-  file.append("str.\n");
-  file.append("return 0\n");
-  file.append("}");
-
-  buffers[path] = file;
-
-  auto results=tu.get_code_completions(buffers, 4, 5);
+  auto results=tu.get_code_completions(buffer, 4, 5);
   // ]
 
   clang::CompletionString str = results.get(0);

--- a/tests/Cursor_H_Test.cc
+++ b/tests/Cursor_H_Test.cc
@@ -8,7 +8,7 @@ BOOST_AUTO_TEST_CASE(cursor) {
   std::string path("./case/main.cpp");
 
   clang::Index index(0, 0);
-  clang::TranslationUnit tu(index, path);
+  clang::TranslationUnit tu(index, path, {});
 
   // ]
 

--- a/tests/Diagnostics_Test.cc
+++ b/tests/Diagnostics_Test.cc
@@ -10,15 +10,7 @@ BOOST_AUTO_TEST_CASE(diagnostics_test) {
 
   clang::Index index(0, 0);
 
-  std::map<std::string, std::string> map_buffers;
-  ifstream ifs(path, ifstream::in);
-  stringstream ss;
-  ss << ifs.rdbuf();
-
-  map_buffers["./case/main_error.cpp"]=ss.str();
-
-  std::vector<std::string> args;  
-  clang::TranslationUnit tu(index, path, args, map_buffers);
+  clang::TranslationUnit tu(index, path, {});
   
   auto diagnostics=tu.get_diagnostics();
   BOOST_CHECK(diagnostics.size()==1);

--- a/tests/SourceLocation_H_Test.cc
+++ b/tests/SourceLocation_H_Test.cc
@@ -7,7 +7,7 @@ BOOST_AUTO_TEST_CASE(source_location) {
 
   clang::Index index(0, 0);
 
-  clang::TranslationUnit tu(index, path);
+  clang::TranslationUnit tu(index, path, {});
   auto tokens=tu.get_tokens(0, 113);
 
   auto offsets=(*tokens)[28].offsets;

--- a/tests/Token_H_Test.cc
+++ b/tests/Token_H_Test.cc
@@ -7,7 +7,7 @@ BOOST_AUTO_TEST_CASE(token) {
 
   clang::Index index(0, 0);
 
-  clang::TranslationUnit tu(index, path);
+  clang::TranslationUnit tu(index, path, {});
   
   auto tokens=tu.get_tokens(0, 113);
 

--- a/tests/TranslationUnit_Test.cc
+++ b/tests/TranslationUnit_Test.cc
@@ -7,18 +7,13 @@ BOOST_AUTO_TEST_CASE(translation_unit) {
   std::string path("./case/main.cpp");
 
   clang::Index index(0, 0);
-  clang::TranslationUnit tu(index, path);
+  
+  clang::TranslationUnit tu(index, path, {});
 
-  // ReparseTranslationUnit takes a map with filepath as key
-  // and buffer as value
-  std::map<std::string, std::string> buffers;
+  std::string buffer = "int main(int argc, char *argv[]) {\n"
+                       "std::cout << \"Hello World!\" << std::endl;\n"
+                       "return 0\n"
+                       "}\n";
 
-  // create buffer
-  std::string file = "int main(int argc, char *argv[]) {\n";
-  file.append("std::cout << \"Hello World!\" << std::endl;\n");
-  file.append("return 0\n");
-  file.append("}");
-
-  buffers[path] = file;
-  BOOST_CHECK(tu.ReparseTranslationUnit(buffers) == 0);
+  BOOST_CHECK(tu.ReparseTranslationUnit(buffer) == 0);
 }


### PR DESCRIPTION
@zalox: hope you can look over and merge this soon. The main problem was a bit confusing constructors and methods, and the std::map that forced us to previously do a copy of the source buffer (which is expensive). This is fixed now. 

Mind that only one unsaved buffer is used now when calling the libclang functions. I really do not see any case where sending several unsaved files to libclang is a good idea, at least we would never do that in juCi++. If this is needed anyway (highly doubtful), I suggest that we try find a better solution than std::map, in order to avoid copy. 
