### PR TITLE
Makes unit tests optional through CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required (VERSION 2.8.4)
 set(project_name clangmm)
 project(${project_name})
 
+option(LIBCLANGMM_BUILD_TESTS "Build unit tests" OFF)
+
 if(APPLE)
   set(Boost_USE_STATIC_LIBS "YES")
   set(CMAKE_MACOSX_RPATH 1)
@@ -9,5 +11,7 @@ endif()
 
 add_subdirectory(src)
 
-# enable_testing()
-# add_subdirectory(tests)
+if(libclangmm_BUILD_TESTS)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/README.md
+++ b/README.md
@@ -12,25 +12,19 @@ Developed for [juCi++](https://github.com/cppit/jucipp) - a lightweight platform
 See [installation guide](https://github.com/cppit/libclangmm/blob/master/docs/install.md)
 
 # Tests #
-The compilation of the tests are disabled due to ease of installation. Simply enter CMakeList.txt and uncomment the last two lines in the file to enable testing.
-
+To run the unit tests, first enable the CMake option `LIBCLANGMM_BUILD_TESTS`:
 ```sh
-# enable_testing()
-# add_subdirectory(tests)
+cmake -DLIBCLANGMM_BUILD_TESTS=ON .
 ```
-Then simply: 
+Then, simply call:
 ```sh
-cmake .
 make
 ctest
 ```
-If you want an more detailed look at the tests run the binary instead
+You may also run the test binary directly to get more details:
 ```sh
-cmake .
 make
 cd tests
 ./clangmm_tests --log_level=all
 ```
-To see more log parameters see [here](http://www.boost.org/doc/libs/1_58_0/libs/test/doc/html/utf/user-guide/runtime-config/reference.html).
-
-
+For more options, see the [documentation of boost’s unit testing framework](http://www.boost.org/doc/libs/1_58_0/libs/test/doc/html/utf/user-guide/runtime-config/reference.html).


### PR DESCRIPTION
I added a CMake option that causes unit tests to be built (if set). By default, unit test are disabled. I updated the documentation accordingly.

I propose this merge request because I wanted to check out libclangmm and run the tests and noticed the current quirk necessary for doing that.

Aside from this merge request, the unit tests fail on my machine. I will file an issue for that later :).
