### PR TITLE
Added Cursor::get_kind_spelling

### DIFF
--- a/src/cursor.cc
+++ b/src/cursor.cc
@@ -22,6 +22,10 @@ clangmm::Cursor::Kind clangmm::Cursor::get_kind() const {
   return static_cast<Kind>(clang_getCursorKind(cx_cursor));
 }
 
+std::string clangmm::Cursor::get_kind_spelling() const {
+  return to_string(clang_getCursorKindSpelling(clang_getCursorKind(cx_cursor)));
+}
+
 bool clangmm::Cursor::is_similar_kind(Kind kind, Kind other_kind) {
   auto is_function_or_method=[](Kind kind) {
     if(kind==Kind::FunctionDecl || kind==Kind::CXXMethod || kind==Kind::FunctionTemplate)

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -191,6 +191,7 @@ namespace clangmm {
     Cursor() { cx_cursor=clang_getNullCursor(); }
     Cursor(const CXCursor &cx_cursor) : cx_cursor(cx_cursor) {}
     Kind get_kind() const;
+    std::string get_kind_spelling() const;
     static bool is_similar_kind(Kind kind, Kind other_kind);
     Type get_type() const;
     SourceLocation get_source_location() const;


### PR DESCRIPTION
Hi!
i've added a `Cursor::get_kind_spelling()` method which wraps a `clang_getCursorKindSpelling(clang_getCursorKind(cx_cursor))` call.

The reason to not use `to_string( clang_getCursorKindSpelling( static_cast<CXCursorKind>(mycursor.get_kind()) ) )` is the unsafe `CXString` return and the necessary `static_cast` which makes things quite bulky. Compare this to `mycursor.get_kind_spelling()`.