### PR TITLE
Added Cursor::get_children() method

### DIFF
--- a/src/cursor.cc
+++ b/src/cursor.cc
@@ -157,6 +157,18 @@ clangmm::Cursor clangmm::Cursor::get_semantic_parent() const {
   return Cursor(clang_getCursorSemanticParent(cx_cursor));
 }
 
+std::vector<clangmm::Cursor> clangmm::Cursor::get_children() const {
+  std::vector<Cursor> result;
+  clang_visitChildren(cx_cursor,
+    [](CXCursor cur, CXCursor /*parent*/, CXClientData data) {
+      static_cast<std::vector<Cursor>*>(data)->emplace_back(cur);
+      return CXChildVisit_Continue;
+    },
+    &result
+  );
+  return result;
+}
+
 std::vector<clangmm::Cursor> clangmm::Cursor::get_arguments() const {
   std::vector<Cursor> cursors;
   auto size=clang_Cursor_getNumArguments(cx_cursor);

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -208,6 +208,7 @@ namespace clangmm {
     Cursor get_canonical() const;
     Cursor get_definition() const;
     Cursor get_semantic_parent() const;
+    std::vector<Cursor> get_children() const;
     std::vector<Cursor> get_arguments() const;
     std::vector<Cursor> get_all_overridden_cursors() const;
     operator bool() const;


### PR DESCRIPTION
While this is not an 1:1 mapping of the original API, it's very helpful for tree-like access to the AST, e.g. like this:

```cpp
void print_tree(Cursor c, int level=0)
{
  for (int i=0; i<level; i++) cout << "|   ";
  cout << c.get_kind_spelling() << ": " << c.get_spelling() << endl;
  for (auto& child : c.get_children())
    print_tree(child, level+1);
}
```